### PR TITLE
Add evolutions and fossils pages; Update Chespin trade requirement

### DIFF
--- a/docs/evolutions.md
+++ b/docs/evolutions.md
@@ -1,0 +1,463 @@
+| Base             | Evolution             | Method   | Detail                                           |
+| :--------------- | :-------------------- | :------- | :----------------------------------------------- |
+| Bulbasaur        | Ivysaur               | Level Up | Level 16                                         |
+| Ivysaur          | Venusaur              | Level Up | Level 32                                         |
+| Charmander       | Charmeleon            | Level Up | Level 16                                         |
+| Charmeleon       | Charizard             | Level Up | Level 36                                         |
+| Squirtle         | Wartortle             | Level Up | Level 16                                         |
+| Wartortle        | Blastoise             | Level Up | Level 36                                         |
+| Caterpie         | Metapod               | Level Up | Level 7                                          |
+| Metapod          | Butterfree            | Level Up | Level 10                                         |
+| Weedle           | Kakuna                | Level Up | Level 7                                          |
+| Kakuna           | Beedrill              | Level Up | Level 10                                         |
+| Pidgey           | Pidgeotto             | Level Up | Level 18                                         |
+| Pidgeotto        | Pidgeot               | Level Up | Level 36                                         |
+| Rattata          | Raticate              | Level Up | Level 20                                         |
+| Rattata-Alola    | Raticate-Alola        | Level Up | Nighttime + Level 20                             |
+| Spearow          | Fearow                | Level Up | Level 20                                         |
+| Ekans            | Arbok                 | Level Up | Level 22                                         |
+| Pichu            | Pikachu               | Level Up | Happiness + Level Up                             |
+| Pikachu          | Raichu                | Use Item | Thunder Stone                                    |
+| Pikachu          | Raichu-Alola          | Use Item | Water Stone                                      |
+| Sandshrew        | Sandslash             | Level Up | Level 22                                         |
+| Sandshrew-Alola  | Sandslash-Alola       | Use Item | Ice Stone                                        |
+| Nidoran♀         | Nidorina              | Level Up | Level 16                                         |
+| Nidorina         | Nidoqueen             | Use Item | Moon Stone                                       |
+| Nidoran♂         | Nidorino              | Level Up | Level 16                                         |
+| Nidorino         | Nidoking              | Use Item | Moon Stone                                       |
+| Cleffa           | Clefairy              | Level Up | Happiness + Level Up                             |
+| Clefairy         | Clefable              | Use Item | Moon Stone                                       |
+| Vulpix           | Ninetales             | Use Item | Fire Stone                                       |
+| Vulpix-Alola     | Ninetales-Alola       | Use Item | Ice Stone                                        |
+| Igglybuff        | Jigglypuff            | Level Up | Happiness + Level Up                             |
+| Jigglypuff       | Wigglytuff            | Use Item | Moon Stone                                       |
+| Zubat            | Golbat                | Level Up | Level 22                                         |
+| Oddish           | Gloom                 | Level Up | Level 21                                         |
+| Gloom            | Vileplume             | Use Item | Leaf Stone                                       |
+| Paras            | Parasect              | Level Up | Level 24                                         |
+| Venonat          | Venomoth              | Level Up | Level 31                                         |
+| Diglett          | Dugtrio               | Level Up | Level 26                                         |
+| Diglett-Alola    | Dugtrio-Alola         | Level Up | Level 26                                         |
+| Meowth           | Persian               | Level Up | Level 28                                         |
+| Meowth-Alola     | Persian-Alola         | Level Up | Happiness + Level Up                             |
+| Psyduck          | Golduck               | Level Up | Level 33                                         |
+| Mankey           | Primeape              | Level Up | Level 28                                         |
+| Growlithe        | Arcanine              | Use Item | Fire Stone                                       |
+| Poliwag          | Poliwhirl             | Level Up | Level 25                                         |
+| Poliwhirl        | Poliwrath             | Use Item | Water Stone                                      |
+| Abra             | Kadabra               | Level Up | Level 16                                         |
+| Kadabra          | Alakazam              | Use Item | Link Cable                                       |
+| Machop           | Machoke               | Level Up | Level 28                                         |
+| Machoke          | Machamp               | Use Item | Link Cable                                       |
+| Bellsprout       | Weepinbell            | Level Up | Level 21                                         |
+| Weepinbell       | Victreebel            | Use Item | Leaf Stone                                       |
+| Tentacool        | Tentacruel            | Level Up | Level 30                                         |
+| Geodude          | Graveler              | Level Up | Level 25                                         |
+| Geodude-Alola    | Graveler-Alola        | Level Up | Level 25                                         |
+| Graveler         | Golem                 | Use Item | Link Cable                                       |
+| Graveler-Alola   | Golem-Alola           | Use Item | Link Cable                                       |
+| Ponyta           | Rapidash              | Level Up | Level 40                                         |
+| Ponyta-Galar     | Rapidash-Galar        | Level Up | Level 40                                         |
+| Slowpoke         | Slowbro               | Level Up | Level 37                                         |
+| Slowpoke-Galar   | Slowbro-Galar         | Use Item | Galar Cuff                                       |
+| Magnemite        | Magneton              | Level Up | Level 30                                         |
+| Doduo            | Dodrio                | Level Up | Level 31                                         |
+| Seel             | Dewgong               | Level Up | Level 34                                         |
+| Grimer-Alola     | Muk-Alola             | Level Up | Level 38                                         |
+| Shellder         | Cloyster              | Use Item | Water Stone                                      |
+| Gastly           | Haunter               | Level Up | Level 25                                         |
+| Haunter          | Gengar                | Use Item | Link Cable                                       |
+| Drowzee          | Hypno                 | Level Up | Level 26                                         |
+| Krabby           | Kingler               | Level Up | Level 28                                         |
+| Voltorb          | Electrode             | Level Up | Level 30                                         |
+| Exeggcute        | Exeggutor             | Use Item | Leaf Stone                                       |
+| Exeggcute        | Exeggutor-Alola       | Use Item | Link Cable                                       |
+| Cubone           | Marowak               | Level Up | Level 28                                         |
+| Cubone           | Marowak-Alola         | Use Item | Fire Stone                                       |
+| Tyrogue          | Hitmonlee             | Level Up | Attack > Defense + Level 20                      |
+| Tyrogue          | Hitmonchan            | Level Up | Attack < Defense + Level 20                      |
+| Koffing          | Weezing               | Use Item | Link Cable                                       |
+| Koffing          | Weezing-Galar         | Level Up | Level 35                                         |
+| Rhyhorn          | Rhydon                | Level Up | Level 42                                         |
+| Happiny          | Chansey               | Level Up | Oval Stone                                       |
+| Horsea           | Seadra                | Level Up | Level 32                                         |
+| Goldeen          | Seaking               | Level Up | Level 33                                         |
+| Staryu           | Starmie               | Use Item | Water Stone                                      |
+| Mime Jr.         | Mr. Mime              | Level Up | Learn Mimic (Level 15) + Level Up                |
+| Mime Jr.         | Mr. Mime-Galar        | Use Item | Ice Stone                                        |
+| Smoochum         | Jynx                  | Level Up | Level 30                                         |
+| Elekid           | Electabuzz            | Level Up | Level 30                                         |
+| Magby            | Magmar                | Level Up | Level 30                                         |
+| Magikarp         | Gyarados              | Level Up | Level 20                                         |
+| Eevee            | Vaporeon              | Use Item | Water Stone                                      |
+| Eevee            | Jolteon               | Use Item | Thunder Stone                                    |
+| Eevee            | Flareon               | Use Item | Fire Stone                                       |
+| Omanyte          | Omastar               | Level Up | Level 40                                         |
+| Kabuto           | Kabutops              | Level Up | Level 40                                         |
+| Munchlax         | Snorlax               | Level Up | Happiness + Level Up                             |
+| Dratini          | Dragonair             | Level Up | Level 30                                         |
+| Dragonair        | Dragonite             | Level Up | Level 55                                         |
+| Chikorita        | Bayleef               | Level Up | Level 16                                         |
+| Bayleef          | Meganium              | Level Up | Level 32                                         |
+| Cyndaquil        | Quilava               | Level Up | Level 14                                         |
+| Quilava          | Typhlosion            | Level Up | Level 36                                         |
+| Quilava          | Typhlosion-Hisui      | Use Item | Link Cable                                       |
+| Totodile         | Croconaw              | Level Up | Level 18                                         |
+| Croconaw         | Feraligatr            | Level Up | Level 30                                         |
+| Sentret          | Furret                | Level Up | Level 15                                         |
+| Hoothoot         | Noctowl               | Level Up | Level 20                                         |
+| Ledyba           | Ledian                | Level Up | Level 18                                         |
+| Spinarak         | Ariados               | Level Up | Level 22                                         |
+| Golbat           | Crobat                | Level Up | Happiness + Level Up                             |
+| Chinchou         | Lanturn               | Level Up | Level 27                                         |
+| Togepi           | Togetic               | Level Up | Happiness + Level Up                             |
+| Natu             | Xatu                  | Level Up | Level 25                                         |
+| Mareep           | Flaaffy               | Level Up | Level 15                                         |
+| Flaaffy          | Ampharos              | Level Up | Level 30                                         |
+| Gloom            | Bellossom             | Use Item | Sun Stone                                        |
+| Azurill          | Marill                | Level Up | Happiness + Level Up                             |
+| Marill           | Azumarill             | Level Up | Level 18                                         |
+| Bonsly           | Sudowoodo             | Level Up | Learn Mimic (Level 15) + Level Up                |
+| Poliwhirl        | Politoed              | Use Item | Link Cable                                       |
+| Hoppip           | Skiploom              | Level Up | Level 18                                         |
+| Skiploom         | Jumpluff              | Level Up | Level 27                                         |
+| Sunkern          | Sunflora              | Use Item | Sun Stone                                        |
+| Wooper           | Quagsire              | Level Up | Level 20                                         |
+| Eevee            | Espeon                | Level Up | Happiness + Daytime + Level Up OR Sun Stone      |
+| Eevee            | Umbreon               | Level Up | Happiness + Nighttime + Level Up OR Moon Stone   |
+| Slowpoke         | Slowking              | Use Item | King's Rock                                      |
+| Slowpoke-Galar   | Slowking-Galar        | Use Item | Galar Wreath                                     |
+| Wynaut           | Wobbuffet             | Level Up | Level 15                                         |
+| Pineco           | Forretress            | Level Up | Level 31                                         |
+| Onix             | Steelix               | Use Item | Metal Coat                                       |
+| Snubbull         | Granbull              | Level Up | Level 23                                         |
+| Scyther          | Scizor                | Use Item | Metal Coat                                       |
+| Teddiursa        | Ursaring              | Level Up | Level 30                                         |
+| Slugma           | Magcargo              | Level Up | Level 38                                         |
+| Swinub           | Piloswine             | Level Up | Level 33                                         |
+| Remoraid         | Octillery             | Level Up | Level 25                                         |
+| Mantyke          | Mantine               | Level Up | Remoraid in Team + Level Up                      |
+| Houndour         | Houndoom              | Level Up | Level 24                                         |
+| Seadra           | Kingdra               | Use Item | Dragon Scale                                     |
+| Phanpy           | Donphan               | Level Up | Level 25                                         |
+| Porygon          | Porygon2              | Use Item | Up-Grade                                         |
+| Tyrogue          | Hitmontop             | Level Up | Attack = Defense + Level 20                      |
+| Chansey          | Blissey               | Level Up | Happiness + Level Up                             |
+| Larvitar         | Pupitar               | Level Up | Level 30                                         |
+| Pupitar          | Tyranitar             | Level Up | Level 55                                         |
+| Treecko          | Grovyle               | Level Up | Level 16                                         |
+| Grovyle          | Sceptile              | Level Up | Level 36                                         |
+| Torchic          | Combusken             | Level Up | Level 16                                         |
+| Combusken        | Blaziken              | Level Up | Level 36                                         |
+| Mudkip           | Marshtomp             | Level Up | Level 16                                         |
+| Marshtomp        | Swampert              | Level Up | Level 36                                         |
+| Poochyena        | Mightyena             | Level Up | Level 18                                         |
+| Zigzagoon        | Linoone               | Level Up | Level 20                                         |
+| Zigzagoon-Galar  | Linoone-Galar         | Level Up | Level 20                                         |
+| Wurmple          | Silcoon               | Level Up | Level 7                                          |
+| Silcoon          | Beautifly             | Level Up | Level 10                                         |
+| Wurmple          | Cascoon               | Level Up | Level 7                                          |
+| Cascoon          | Dustox                | Level Up | Level 10                                         |
+| Lotad            | Lombre                | Level Up | Level 14                                         |
+| Lombre           | Ludicolo              | Use Item | Water Stone                                      |
+| Seedot           | Nuzleaf               | Level Up | Level 14                                         |
+| Nuzleaf          | Shiftry               | Use Item | Leaf Stone                                       |
+| Taillow          | Swellow               | Level Up | Level 22                                         |
+| Wingull          | Pelipper              | Level Up | Level 25                                         |
+| Ralts            | Kirlia                | Level Up | Level 20                                         |
+| Kirlia           | Gardevoir             | Level Up | Level 30                                         |
+| Surskit          | Masquerain            | Level Up | Level 22                                         |
+| Shroomish        | Breloom               | Level Up | Level 23                                         |
+| Slakoth          | Vigoroth              | Level Up | Level 18                                         |
+| Vigoroth         | Slaking               | Level Up | Level 36                                         |
+| Nincada          | Ninjask               | Level Up | Level 20                                         |
+| Nincada          | Shedinja              | Use Item | Dusk Stone                                       |
+| Whismur          | Loudred               | Level Up | Level 20                                         |
+| Loudred          | Exploud               | Level Up | Level 40                                         |
+| Makuhita         | Hariyama              | Level Up | Level 24                                         |
+| Skitty           | Delcatty              | Use Item | Moon Stone                                       |
+| Aron             | Lairon                | Level Up | Level 32                                         |
+| Lairon           | Aggron                | Level Up | Level 42                                         |
+| Meditite         | Medicham              | Level Up | Level 37                                         |
+| Electrike        | Manectric             | Level Up | Level 26                                         |
+| Budew            | Roselia               | Level Up | Happiness + Daytime + Level Up                   |
+| Gulpin           | Swalot                | Level Up | Level 26                                         |
+| Carvanha         | Sharpedo              | Level Up | Level 30                                         |
+| Wailmer          | Wailord               | Level Up | Level 40                                         |
+| Numel            | Camerupt              | Level Up | Level 33                                         |
+| Spoink           | Grumpig               | Level Up | Level 32                                         |
+| Trapinch         | Vibrava               | Level Up | Level 35                                         |
+| Vibrava          | Flygon                | Level Up | Level 45                                         |
+| Cacnea           | Cacturne              | Level Up | Level 32                                         |
+| Swablu           | Altaria               | Level Up | Level 35                                         |
+| Barboach         | Whiscash              | Level Up | Level 30                                         |
+| Corphish         | Crawdaunt             | Level Up | Level 30                                         |
+| Baltoy           | Claydol               | Level Up | Level 36                                         |
+| Lileep           | Cradily               | Level Up | Level 40                                         |
+| Anorith          | Armaldo               | Level Up | Level 40                                         |
+| Feebas           | Milotic               | Use Item | Prism Scale                                      |
+| Shuppet          | Banette               | Level Up | Level 37                                         |
+| Duskull          | Dusclops              | Level Up | Level 37                                         |
+| Chingling        | Chimecho              | Level Up | Happiness + Nighttime + Level Up                 |
+| Snorunt          | Glalie                | Level Up | Level 42                                         |
+| Spheal           | Sealeo                | Level Up | Level 32                                         |
+| Sealeo           | Walrein               | Level Up | Level 44                                         |
+| Clamperl         | Huntail               | Use Item | Deep Sea Tooth                                   |
+| Clamperl         | Gorebyss              | Use Item | Deep Sea Scale                                   |
+| Bagon            | Shelgon               | Level Up | Level 30                                         |
+| Shelgon          | Salamence             | Level Up | Level 50                                         |
+| Beldum           | Metang                | Level Up | Level 20                                         |
+| Metang           | Metagross             | Level Up | Level 45                                         |
+| Turtwig          | Grotle                | Level Up | Level 18                                         |
+| Grotle           | Torterra              | Level Up | Level 32                                         |
+| Chimchar         | Monferno              | Level Up | Level 14                                         |
+| Monferno         | Infernape             | Level Up | Level 36                                         |
+| Piplup           | Prinplup              | Level Up | Level 16                                         |
+| Prinplup         | Empoleon              | Level Up | Level 36                                         |
+| Starly           | Staravia              | Level Up | Level 14                                         |
+| Staravia         | Staraptor             | Level Up | Level 34                                         |
+| Bidoof           | Bibarel               | Level Up | Level 15                                         |
+| Kricketot        | Kricketune            | Level Up | Level 10                                         |
+| Shinx            | Luxio                 | Level Up | Level 15                                         |
+| Luxio            | Luxray                | Level Up | Level 30                                         |
+| Roselia          | Roserade              | Use Item | Shiny Stone                                      |
+| Cranidos         | Rampardos             | Level Up | Level 30                                         |
+| Shieldon         | Bastiodon             | Level Up | Level 30                                         |
+| Burmy            | Wormadam              | Level Up | Female + Level 20                                |
+| Burmy            | Mothim                | Level Up | Male + Level 20                                  |
+| Combee           | Vespiquen             | Level Up | Female + Level 21                                |
+| Buizel           | Floatzel              | Level Up | Level 26                                         |
+| Cherubi          | Cherrim               | Level Up | Level 25                                         |
+| Shellos          | Gastrodon             | Level Up | Level 30                                         |
+| Aipom            | Ambipom               | Level Up | Learn Double Hit (Level 32) + Level Up           |
+| Drifloon         | Drifblim              | Level Up | Level 28                                         |
+| Buneary          | Lopunny               | Level Up | Happiness + Level Up                             |
+| Misdreavus       | Mismagius             | Use Item | Dusk Stone                                       |
+| Murkrow          | Honchkrow             | Use Item | Dusk Stone                                       |
+| Glameow          | Purugly               | Level Up | Level 38                                         |
+| Stunky           | Skuntank              | Level Up | Level 34                                         |
+| Bronzor          | Bronzong              | Level Up | Level 33                                         |
+| Gible            | Gabite                | Level Up | Level 24                                         |
+| Gabite           | Garchomp              | Level Up | Level 48                                         |
+| Riolu            | Lucario               | Level Up | Happiness + Daytime + Level Up                   |
+| Hippopotas       | Hippowdon             | Level Up | Level 34                                         |
+| Skorupi          | Drapion               | Level Up | Level 40                                         |
+| Croagunk         | Toxicroak             | Level Up | Level 37                                         |
+| Finneon          | Lumineon              | Level Up | Level 31                                         |
+| Snover           | Abomasnow             | Level Up | Level 40                                         |
+| Sneasel          | Weavile               | Level Up | Razor Claw                                       |
+| Magneton         | Magnezone             | Use Item | Thunder Stone                                    |
+| Lickitung        | Lickilicky            | Level Up | Learn Rollout (Level 33) + Level Up              |
+| Rhydon           | Rhyperior             | Use Item | Protector                                        |
+| Tangela          | Tangrowth             | Level Up | Learn Ancient Power (Level 38) + Level Up        |
+| Electabuzz       | Electivire            | Use Item | Electirizer                                      |
+| Magmar           | Magmortar             | Use Item | Magmarizer                                       |
+| Togetic          | Togekiss              | Use Item | Shiny Stone                                      |
+| Yanma            | Yanmega               | Level Up | Learn Ancient Power (Level 33) + Level Up        |
+| Eevee            | Leafeon               | Use Item | Leaf Stone                                       |
+| Eevee            | Glaceon               | Use Item | Ice Stone                                        |
+| Gligar           | Gliscor               | Use Item | Razor Fang                                       |
+| Piloswine        | Mamoswine             | Level Up | Learn Ancient Power (Level 1 Relearn) + Level Up |
+| Porygon2         | Porygon-Z             | Use Item | Link Cable                                       |
+| Kirlia           | Gallade               | Use Item | Male + Dawn Stone                                |
+| Nosepass         | Probopass             | Use Item | Thunder Stone                                    |
+| Dusclops         | Dusknoir              | Use Item | Repear Cloth                                     |
+| Snorunt          | Froslass              | Use Item | Female + Dawn Stone                              |
+| Shaymin          | Shaymin-Sky           | Use Item | Gracidea                                         |
+| Snivy            | Servine               | Level Up | Level 17                                         |
+| Servine          | Serperior             | Level Up | Level 36                                         |
+| Tepig            | Pignite               | Level Up | Level 17                                         |
+| Pignite          | Emboar                | Level Up | Level 36                                         |
+| Oshawott         | Dewott                | Level Up | Level 17                                         |
+| Dewott           | Samurott              | Level Up | Level 36                                         |
+| Dewott           | Samurott-Hisui        | Use Item | Link Cable                                       |
+| Patrat           | Watchog               | Level Up | Level 20                                         |
+| Lillipup         | Herdier               | Level Up | Level 16                                         |
+| Herdier          | Stoutland             | Level Up | Level 32                                         |
+| Purrloin         | Liepard               | Level Up | Level 20                                         |
+| Pansage          | Simisage              | Use Item | Leaf Stone                                       |
+| Pansear          | Simisear              | Use Item | Fire Stone                                       |
+| Panpour          | Simipour              | Use Item | Water Stone                                      |
+| Munna            | Musharna              | Use Item | Moon Stone                                       |
+| Pidove           | Tranquill             | Level Up | Level 21                                         |
+| Tranquill        | Unfezant              | Level Up | Level 32                                         |
+| Blitzle          | Zebstrika             | Level Up | Level 27                                         |
+| Roggenrola       | Boldore               | Level Up | Level 25                                         |
+| Boldore          | Gigalith              | Use Item | Link Cable                                       |
+| Woobat           | Swoobat               | Level Up | Happiness + Level Up                             |
+| Drilbur          | Excadrill             | Level Up | Level 31                                         |
+| Timburr          | Gurdurr               | Level Up | Level 25                                         |
+| Gurdurr          | Conkeldurr            | Use Item | Link Cable                                       |
+| Tympole          | Palpitoad             | Level Up | Level 25                                         |
+| Palpitoad        | Seismitoad            | Level Up | Level 36                                         |
+| Sewaddle         | Swadloon              | Level Up | Level 20                                         |
+| Swadloon         | Leavanny              | Level Up | Happiness + Level Up                             |
+| Venipede         | Whirlipede            | Level Up | Level 22                                         |
+| Whirlipede       | Scolipede             | Level Up | Level 30                                         |
+| Cottonee         | Whimsicott            | Use Item | Sun Stone                                        |
+| Petilil          | Lilligant             | Use Item | Sun Stone                                        |
+| Sandile          | Krokorok              | Level Up | Level 29                                         |
+| Krokorok         | Krookodile            | Level Up | Level 40                                         |
+| Darumaka         | Darmanitan            | Level Up | Level 35                                         |
+| Darumaka-Galar   | Darmanitan-Galar      | Use Item | Ice Stone                                        |
+| Dwebble          | Crustle               | Level Up | Level 34                                         |
+| Scraggy          | Scrafty               | Level Up | Level 39                                         |
+| Yamask           | Cofagrigus            | Level Up | Level 34                                         |
+| Tirtouga         | Carracosta            | Level Up | Level 37                                         |
+| Archen           | Archeops              | Level Up | Level 37                                         |
+| Trubbish         | Garbodor              | Level Up | Level 36                                         |
+| Zorua            | Zoroark               | Level Up | Level 30                                         |
+| Minccino         | Cinccino              | Use Item | Shiny Stone                                      |
+| Gothita          | Gothorita             | Level Up | Level 32                                         |
+| Gothorita        | Gothitelle            | Level Up | Level 41                                         |
+| Solosis          | Duosion               | Level Up | Level 32                                         |
+| Duosion          | Reuniclus             | Level Up | Level 41                                         |
+| Ducklett         | Swanna                | Level Up | Level 35                                         |
+| Vanillite        | Vanillish             | Level Up | Level 35                                         |
+| Vanillish        | Vanilluxe             | Level Up | Level 47                                         |
+| Deerling         | Sawsbuck              | Level Up | Level 34                                         |
+| Karrablast       | Escavalier            | Use Item | Link Cable                                       |
+| Foongus          | Amoonguss             | Level Up | Level 39                                         |
+| Frillish         | Jellicent             | Level Up | Level 40                                         |
+| Joltik           | Galvantula            | Level Up | Level 36                                         |
+| Ferroseed        | Ferrothorn            | Level Up | Level 40                                         |
+| Klink            | Klang                 | Level Up | Level 38                                         |
+| Klang            | Klinklang             | Level Up | Level 49                                         |
+| Tynamo           | Eelektrik             | Level Up | Level 39                                         |
+| Eelektrik        | Eelektross            | Use Item | Thunder Stone                                    |
+| Elgyem           | Beheeyem              | Level Up | Level 42                                         |
+| Litwick          | Lampent               | Level Up | Level 41                                         |
+| Lampent          | Chandelure            | Use Item | Dusk Stone                                       |
+| Axew             | Fraxure               | Level Up | Level 38                                         |
+| Fraxure          | Haxorus               | Level Up | Level 48                                         |
+| Cubchoo          | Beartic               | Level Up | Level 37                                         |
+| Shelmet          | Accelgor              | Use Item | Link Cable                                       |
+| Mienfoo          | Mienshao              | Level Up | Level 50                                         |
+| Golett           | Golurk                | Level Up | Level 43                                         |
+| Pawniard         | Bisharp               | Level Up | Level 52                                         |
+| Rufflet          | Braviary              | Level Up | Level 54                                         |
+| Vullaby          | Mandibuzz             | Level Up | Level 54                                         |
+| Deino            | Zweilous              | Level Up | Level 50                                         |
+| Zweilous         | Hydreigon             | Level Up | Level 64                                         |
+| Larvesta         | Volcarona             | Level Up | Level 59                                         |
+| Tornadus         | Tornadus-Therian      | Use Item | Reveal Glass                                     |
+| Thundurus        | Thundurus-Therian     | Use Item | Reveal Glass                                     |
+| Landorus         | Landorus-Therian      | Use Item | Reveal Glass                                     |
+| Chespin          | Quilladin             | Level Up | Level 16                                         |
+| Quilladin        | Chesnaught            | Level Up | Level 36                                         |
+| Fennekin         | Braixen               | Level Up | Level 16                                         |
+| Braixen          | Delphox               | Level Up | Level 36                                         |
+| Froakie          | Frogadier             | Level Up | Level 16                                         |
+| Frogadier        | Greninja              | Level Up | Level 36                                         |
+| Bunnelby         | Diggersby             | Level Up | Level 20                                         |
+| Fletchling       | Fletchinder           | Level Up | Level 17                                         |
+| Fletchinder      | Talonflame            | Level Up | Level 35                                         |
+| Scatterbug       | Spewpa                | Level Up | Level 9                                          |
+| Spewpa           | Vivillon              | Level Up | Level 12                                         |
+| Litleo           | Pyroar                | Level Up | Level 35                                         |
+| Flabébé          | Floette               | Level Up | Level 19                                         |
+| Floette          | Florges               | Use Item | Shiny Stone                                      |
+| Skiddo           | Gogoat                | Level Up | Level 32                                         |
+| Pancham          | Pangoro               | Level Up | Level 32                                         |
+| Espurr           | Meowstic              | Level Up | Level 25                                         |
+| Honedge          | Doublade              | Level Up | Level 35                                         |
+| Doublade         | Aegislash             | Use Item | Dusk Stone                                       |
+| Spritzee         | Aromatisse            | Use Item | Sachet                                           |
+| Swirlix          | Slurpuff              | Use Item | Whip Dream                                       |
+| Inkay            | Malamar               | Level Up | Level 30                                         |
+| Binacle          | Barbaracle            | Level Up | Level 39                                         |
+| Skrelp           | Dragalge              | Level Up | Level 48                                         |
+| Clauncher        | Clawitzer             | Level Up | Level 37                                         |
+| Helioptile       | Heliolisk             | Use Item | Sun Stone                                        |
+| Tyrunt           | Tyrantrum             | Level Up | Daytime + Level 39                               |
+| Amaura           | Aurorus               | Level Up | Nighttime + Level 39                             |
+| Aurorus          | Sylveon               | Level Up | Happiness + Fairy-type move + Level Up           |
+| Goomy            | Sliggoo               | Level Up | Level 40                                         |
+| Sliggoo          | Goodra                | Level Up | Rain + Level 50                                  |
+| Phantump         | Trevenant             | Use Item | Link Cable                                       |
+| Pumpkaboo        | Gourgeist             | Use Item | Link Cable                                       |
+| Bergmite         | Avalugg               | Level Up | Level 37                                         |
+| Noibat           | Noivern               | Level Up | Level 48                                         |
+| Hoopa            | Hoopa-Unbound         | Use Item | Prison Bottle                                    |
+| Rowlet           | Dartrix               | Level Up | Level 17                                         |
+| Dartrix          | Decidueye             | Level Up | Level 34                                         |
+| Dartrix          | Decidueye-Hisui       | Use Item | Link Cable                                       |
+| Litten           | Torracat              | Level Up | Level 17                                         |
+| Torracat         | Incineroar            | Level Up | Level 34                                         |
+| Popplio          | Brionne               | Level Up | Level 17                                         |
+| Brionne          | Primarina             | Level Up | Level 34                                         |
+| Pikipek          | Trumbeak              | Level Up | Level 14                                         |
+| Trumbeak         | Toucannon             | Level Up | Level 28                                         |
+| Yungoos          | Gumshoos              | Level Up | Level 20                                         |
+| Grubbin          | Charjabug             | Level Up | Level 20                                         |
+| Charjabug        | Vikavolt              | Use Item | Thunder Stone                                    |
+| Crabrawler       | Crabominable          |          | Ice Stone                                        |
+| Cutiefly         | Ribombee              | Level Up | Level 25                                         |
+| Rockruff         | Lycanroc-Midday       | Level Up | 4am-5pm + Level 25 OR Dawn Stone                 |
+| Rockruff         | Lycanroc-Midnight     | Level Up | 8pm-4am + Level 25 OR Moon Stone                 |
+| Rockruff         | Lycanroc-Dusk         | Level Up | 5pm-8pm + Level 25 OR Dusk Stone                 |
+| Mareanie         | Toxapex               | Level Up | Level 38                                         |
+| Mudbray          | Mudsdale              | Level Up | Level 30                                         |
+| Dewpider         | Araquanid             | Level Up | Level 22                                         |
+| Fomantis         | Lurantis              | Level Up | Daytime + Level 34                               |
+| Morelull         | Shiinotic             | Level Up | Level 24                                         |
+| Salandit         | Salazzle              | Level Up | Female + Level 33                                |
+| Stufful          | Bewear                | Level Up | Level 27                                         |
+| Bounsweet        | Steenee               | Level Up | Level 18                                         |
+| Steenee          | Tsareena              | Level Up | Learn Stomp (Level 29) + Level Up                |
+| Wimpod           | Golisopod             | Level Up | Level 30                                         |
+| Sandygast        | Palossand             | Level Up | Level 42                                         |
+| Type: Null       | Silvally              | Level Up | Happiness + Level Up                             |
+| Jangmo-o         | Hakamo-o              | Level Up | Level 35                                         |
+| Hakamo-o         | Kommo-o               | Level Up | Level 45                                         |
+| Cosmog           | Cosmoem               | Level Up | Level 43                                         |
+| Cosmoem          | Solgaleo              | Level Up | Daytime + Level 53                               |
+| Cosmoem          | Lunala                | Level Up | Nighttime + Level 53                             |
+| Poipole          | Naganadel             | Level Up | Learn Dragon Pulse (Level 1 Re-learn) + Level Up |
+| Grookey          | Thwackey              | Level Up | Level 16                                         |
+| Thwackey         | Rillaboom             | Level Up | Level 35                                         |
+| Scorbunny        | Raboot                | Level Up | Level 16                                         |
+| Raboot           | Cinderace             | Level Up | Level 35                                         |
+| Sobble           | Drizzile              | Level Up | Level 16                                         |
+| Drizzile         | Inteleon              | Level Up | Level 35                                         |
+| Skwovet          | Greedent              | Level Up | Level 24                                         |
+| Rookidee         | Corvisquire           | Level Up | Level 18                                         |
+| Corvisquire      | Corviknight           | Level Up | Level 38                                         |
+| Blipbug          | Dottler               | Level Up | Level 10                                         |
+| Dottler          | Orbeetle              | Level Up | Level 30                                         |
+| Nickit           | Thievul               | Level Up | Level 18                                         |
+| Gossifleur       | Eldegoss              | Level Up | Level 20                                         |
+| Wooloo           | Dubwool               | Level Up | Level 24                                         |
+| Chewtle          | Drednaw               | Level Up | Level 22                                         |
+| Yamper           | Boltund               | Level Up | Level 25                                         |
+| Rolycoly         | Carkol                | Level Up | Level 18                                         |
+| Carkol           | Coalossal             | Level Up | Level 34                                         |
+| Applin           | Flapple               | Use Item | Tart Apple                                       |
+| Applin           | Appletun              | Use Item | Sweet Apple                                      |
+| Silicobra        | Sandaconda            | Level Up | Level 36                                         |
+| Arrokuda         | Barraskewda           | Level Up | Level 26                                         |
+| Toxel            | Toxtricity-Amped      | Level Up | Level 30 (Random form-Wurmple mechanic)          |
+| Toxel            | Toxtricity-Low Key    | Level Up | Level 30 (Random form-Wurmple mechanic)          |
+| Sizzlipede       | Centiskorch           | Level Up | Level 28                                         |
+| Clobbopus        | Grapploct             | Level Up | Learn Taunt (Level 35) + Level Up                |
+| Sinistea         | Polteageist           | Use Item | Chipped Pot                                      |
+| Hatenna          | Hattrem               | Level Up | Level 32                                         |
+| Hattrem          | Hatterene             | Level Up | Level 42                                         |
+| Impidimp         | Morgrem               | Level Up | Level 32                                         |
+| Morgrem          | Grimmsnarl            | Level Up | Level 42                                         |
+| Linoone-Galar    | Obstagoon             | Level Up | Level 35                                         |
+| Meowth-Galar     | Perrserker            | Level Up | Level 28                                         |
+| Corsola-Galar    | Cursola               | Level Up | Level 38                                         |
+| Farfetch'd-Galar | Sirfetch'd            | Level Up | Level 30                                         |
+| Mr. Mime-Galar   | Mr. Rime              | Level Up | Level 42                                         |
+| Yamask-Galar     | Runerigus             | Level Up | Level 35                                         |
+| Milcery          | Alcremie              | Use Item | Sweets                                           |
+| Snom             | Frosmoth              | Level Up | Happiness + Nighttime + Level Up                 |
+| Cufant           | Copperajah            | Level Up | Level 34                                         |
+| Dreepy           | Drakloak              | Level Up | Level 50                                         |
+| Drakloak         | Dragapult             | Level Up | Level 60                                         |
+| Kubfu            | Urshifu-Single Strike | Use Item | Parchment D (Scroll of Darkness)                 |
+| Kubfu            | Urshifu-Rapid Strike  | Use Item | Parchment W (Scroll of Water)                    |
+| Applin           | Dipplin               | Level Up | Level 30                                         |
+| Duraludon        | Archaludon            | Use Item | Link Cable                                       |
+| Dipplin          | Hydrapple             | Level Up | Level 44                                         |

--- a/docs/fossils.md
+++ b/docs/fossils.md
@@ -1,0 +1,19 @@
+| Fossil        | Location                   | Note               |
+| :------------ | :------------------------- | :----------------- |
+| Helix Fossil  | Route 6                    |                    |
+| Dome Fossil   | Route 8 (Desert)           |                    |
+| Old Amber     | Wild Area 5 (Desert) North |                    |
+| Root Fossil   | Wild Area 5 (Desert) North |                    |
+| Claw Fossil   | Wild Area 5 (Desert) South |                    |
+| Skull Fossil  | Wild Area 6 East           |                    |
+| Armor Fossil  | Wild Area 6 (Rixy Chamber) |                    |
+| Cover Fossil  | Wild Area 4 East           |                    |
+| Plume Fossil  | Wild Area 9 (Dragon)       |                    |
+| Jaw Fossil    | Wild Area 3 (Volcano)      |                    |
+| Sail Fossil   | Wild Area 3 North          | needs Surf         |
+| Bird Fossil*  | Route 6                    | Repeatable via NPC |
+| Drake Fossil* | Route 6                    | Repeatable via NPC |
+| Fish Fossil*  | Route 6                    | Repeatable via NPC |
+| Dino Fossil*  | Route 6                    | Repeatable via NPC |
+
+*The Galarian fossils can be obtained in other locations, but the most convenient and repeatable meathod is the NPC on Route 6.

--- a/docs/pokemon/650-chespin.md
+++ b/docs/pokemon/650-chespin.md
@@ -84,7 +84,7 @@
 ## Locations
 | Route | Area | Encounter Rate | Extra Instructions |
         | -- | -- | -- | -- |
-        	| Wild Area 1 Southwest | In Game Trade | 100 | Trade Drakloak for Chespin |
+        	| Wild Area 1 Southwest | In Game Trade | 100 | Trade Dreepy for Chespin |
 
         
 


### PR DESCRIPTION
### Descriptions

This PR adds 2 new docs pages:
- `docs/evolutions.md` - table of all evolution methods as of version `1.2.1.2` 
- `docs/fossils.md`

This PR also updates 1 existing page:
- `docs/pokemon/650-chespin.md` - changing trade requirement from Drakloak to Dreepy to match recent change